### PR TITLE
Add ability to get at the current QApplication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 compiler:
   - clang
 before_install:
-  - sudo apt-add-repository -y ppa:beineri/opt-qt55
+  - sudo apt-add-repository -y ppa:beineri/opt-qt551
   - sudo apt-get update
   - sudo apt-get install -y qt55base qt55declarative
 script:

--- a/qmlbind/include/qmlbind/application.h
+++ b/qmlbind/include/qmlbind/application.h
@@ -7,6 +7,7 @@ extern "C" {
 #endif
 
 QMLBIND_API qmlbind_application qmlbind_application_new(int argc, char **argv);
+QMLBIND_API qmlbind_application qmlbind_application_instance(void);
 QMLBIND_API void qmlbind_application_release(qmlbind_application app);
 QMLBIND_API int qmlbind_application_exec(qmlbind_application app);
 

--- a/qmlbind/src/api_application.cpp
+++ b/qmlbind/src/api_application.cpp
@@ -91,6 +91,11 @@ qmlbind_application qmlbind_application_new(int argc, char **argv)
     return app;
 }
 
+qmlbind_application qmlbind_application_instance(void)
+{
+    return qApp;
+}
+
 void qmlbind_application_release(qmlbind_application app)
 {
     delete app;

--- a/test/application_test.cpp
+++ b/test/application_test.cpp
@@ -14,3 +14,8 @@ TEST_CASE("next_tick")
 
     REQUIRE(called);
 }
+
+TEST_CASE("instance")
+{
+    REQUIRE(qmlbind_application_instance() != nullptr);
+}


### PR DESCRIPTION
Providing access to this function eliminates the need for language
specific bindings to be forced to re-implement tracking of this object.