### PR TITLE
Use rpath to search for libqmlbind from test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,5 @@ script:
   - source /opt/qt55/bin/qt55-env.sh
   - qmake -r QMAKE_CC=$CC QMAKE_CXX=$CXX
   - make
-  - export LD_LIBRARY_PATH=$PWD/qmlbind
   - cd ./test
   - ./test -platform offscreen

--- a/qmlbind/qmlbind.pro
+++ b/qmlbind/qmlbind.pro
@@ -3,8 +3,9 @@ QT += widgets qml quick core-private
 TARGET = qmlbind
 TEMPLATE = lib
 CONFIG += c++11
-
 DEFINES += QMLBIND_LIBRARY
+
+QMAKE_SONAME_PREFIX = @rpath
 
 INCLUDEPATH += $$PWD/include
 

--- a/qmlbind/qmlbind.pro
+++ b/qmlbind/qmlbind.pro
@@ -5,8 +5,6 @@ TEMPLATE = lib
 CONFIG += c++11
 DEFINES += QMLBIND_LIBRARY
 
-QMAKE_SONAME_PREFIX = @rpath
-
 INCLUDEPATH += $$PWD/include
 
 SOURCES += \
@@ -59,6 +57,10 @@ PRIVATE_HEADERS += \
     src/engine.h
 
 HEADERS = $$PUBLIC_HEADERS $$PRIVATE_HEADERS
+
+macx {
+    QMAKE_SONAME_PREFIX = @rpath
+}
 
 unix {
     for(header, PUBLIC_HEADERS) {

--- a/readme.md
+++ b/readme.md
@@ -50,14 +50,9 @@ and then build it:
 ```
 
 ### Run the Tests
-As libqmlbind is built as a dynamic library, you need to change the library search path to be able to run the test.
-```
-# for MacOS X:
-> export DYLD_LIBRARY_PATH=$PWD/qmlbind
-# for all other Unixes:
-> export LD_LIBRARY_PATH=$PWD/qmlbind
-```
-Then, from the main directory:
+
+From the main directory:
+
 ```
 > ./test/test -platform offscreen
 ```

--- a/test/test.pro
+++ b/test/test.pro
@@ -17,7 +17,8 @@ SOURCES += \
 
 QMAKE_CFLAGS += "-std=c89"
 
-LIBS += -L$$PWD/../qmlbind/ -lqmlbind
+QMAKE_RPATHDIR += $$OUT_PWD/../qmlbind
+LIBS += -L$$OUT_PWD/../qmlbind/ -lqmlbind
 INCLUDEPATH += $$PWD/../qmlbind/include $$PWD/lib/Catch/include
 DEPENDPATH += $$PWD/../qmlbind
 


### PR DESCRIPTION
I fixed .pro to use rpath to search for libqmlbind on testing.
It's no longer required to `export LD_LIBRARY_PATH=...` before testing.

cc @florianjacob 