### PR TITLE
Remove unused flags from example .pro

### DIFF
--- a/examples/hello_world_window/hello_world_window.pro
+++ b/examples/hello_world_window/hello_world_window.pro
@@ -1,6 +1,5 @@
 TEMPLATE = app
 CONFIG -= app_bundle
-CONFIG += c++11
 QMAKE_CFLAGS += "-std=c99"
 
 SOURCES += main.c
@@ -8,5 +7,5 @@ SOURCES += main.c
 
 QMAKE_RPATHDIR += $$OUT_PWD/../../qmlbind
 LIBS += -L$$OUT_PWD/../../qmlbind/ -lqmlbind
-INCLUDEPATH += $$PWD/../../qmlbind/include $$PWD/lib/Catch/include
+INCLUDEPATH += $$PWD/../../qmlbind/include
 DEPENDPATH += $$PWD/../../qmlbind


### PR DESCRIPTION
Looks like `CONFIG += c++11` and `INCLUDEPATH += $$PWD/lib/Catch/include` can be removed from example project.