### PR TITLE
Use std::shared_ptr instead of QSharedPointer

### DIFF
--- a/qmlbind/include/qmlbind/qmlbind_global.h
+++ b/qmlbind/include/qmlbind/qmlbind_global.h
@@ -21,7 +21,8 @@
 // but use opaque structs if this is another project and only libqmlbind's header files are included.
 #ifdef QMLBIND_LIBRARY
 
-template <typename T> class QSharedPointer;
+#include <memory>
+
 class QApplication;
 class QQmlComponent;
 class QJSValue;
@@ -50,9 +51,9 @@ typedef QJSValueIterator qmlbind_iterator;
 typedef QByteArray qmlbind_string;
 
 // Use shared pointer for widely referenced classes
-typedef QSharedPointer<QmlBind::Interface> qmlbind_interface;
-typedef QSharedPointer<QmlBind::MetaObject> qmlbind_metaobject;
-typedef QSharedPointer<QmlBind::Exporter> qmlbind_exporter;
+typedef std::shared_ptr<QmlBind::Interface> qmlbind_interface;
+typedef std::shared_ptr<QmlBind::MetaObject> qmlbind_metaobject;
+typedef std::shared_ptr<QmlBind::Exporter> qmlbind_exporter;
 
 typedef QmlBind::SignalEmitter qmlbind_signal_emitter;
 

--- a/qmlbind/src/backref.cpp
+++ b/qmlbind/src/backref.cpp
@@ -7,7 +7,7 @@ Backref::Backref()
 {
 }
 
-Backref::Backref(qmlbind_backref *backref, const QSharedPointer<Interface> &interface) :
+Backref::Backref(qmlbind_backref *backref, const std::shared_ptr<Interface> &interface) :
     mBackref(backref),
     mInterface(interface)
 {

--- a/qmlbind/src/backref.h
+++ b/qmlbind/src/backref.h
@@ -9,21 +9,21 @@ class Backref
 {
 public:
     Backref();
-    Backref(qmlbind_backref *backref, const QSharedPointer<Interface> &interface);
+    Backref(qmlbind_backref *backref, const std::shared_ptr<Interface> &interface);
     Backref(const Backref &other);
     ~Backref();
 
     Backref &operator=(const Backref &other);
 
     qmlbind_backref *backref() const { return mBackref; }
-    QSharedPointer<Interface> interface() const { return mInterface; }
+    std::shared_ptr<Interface> interface() const { return mInterface; }
 
 private:
     void retain();
     void release();
 
     qmlbind_backref *mBackref;
-    QSharedPointer<Interface> mInterface;
+    std::shared_ptr<Interface> mInterface;
 };
 
 } // namespace QmlBind

--- a/qmlbind/src/exporter.h
+++ b/qmlbind/src/exporter.h
@@ -25,7 +25,7 @@ public:
     void addMethod(const char *name, int arity);
     void addSignal(const char *name, const QList<QByteArray> &args);
     void addProperty(const char *name, const char *notifier);
-    QSharedPointer<Interface> interface() const { return mClassRef.interface(); }
+    std::shared_ptr<Interface> interface() const { return mClassRef.interface(); }
 
     Backref classRef() const { return mClassRef; }
     const QMetaObjectBuilder &metaObjectBuilder() const { return mBuilder; }

--- a/qmlbind/src/interface.cpp
+++ b/qmlbind/src/interface.cpp
@@ -45,7 +45,7 @@ void Interface::setProperty(QQmlEngine *engine, const Backref &obj, const QByteA
 
 Backref Interface::newObject(const Backref &klass, SignalEmitter *signalEmitter)
 {
-    return Backref(mHandlers.new_object(klass.backref(), signalEmitter), sharedFromThis());
+    return Backref(mHandlers.new_object(klass.backref(), signalEmitter), shared_from_this());
 }
 
 void Interface::retainObject(qmlbind_backref *ref)

--- a/qmlbind/src/interface.h
+++ b/qmlbind/src/interface.h
@@ -11,7 +11,7 @@ namespace QmlBind {
 
 class Backref;
 
-class Interface : public QEnableSharedFromThis<Interface>
+class Interface : public std::enable_shared_from_this<Interface>
 {
 public:
     Interface(qmlbind_interface_handlers handlers);

--- a/qmlbind/src/metaobject.cpp
+++ b/qmlbind/src/metaobject.cpp
@@ -10,9 +10,9 @@
 
 namespace QmlBind {
 
-MetaObject::MetaObject(const QSharedPointer<const Exporter> &exporter) :
+MetaObject::MetaObject(const std::shared_ptr<const Exporter> &exporter) :
     mExporter(exporter),
-    mPrototype(exporter->metaObjectBuilder().toMetaObject())
+    mPrototype(exporter->metaObjectBuilder().toMetaObject(), free)
 {
     d = mPrototype->d;
 }
@@ -33,8 +33,8 @@ int MetaObject::metaCall(QObject *object, Call call, int index, void **argv) con
     QQmlContext *context = QQmlEngine::contextForObject(object);
     QQmlEngine *engine = context ? context->engine() : 0;
 
-    QSharedPointer<const Exporter> exporter = mExporter;
-    QSharedPointer<Interface> interface = ref.interface();
+    std::shared_ptr<const Exporter> exporter = mExporter;
+    std::shared_ptr<Interface> interface = ref.interface();
 
     switch(call) {
     case QMetaObject::ReadProperty:

--- a/qmlbind/src/metaobject.h
+++ b/qmlbind/src/metaobject.h
@@ -14,16 +14,16 @@ class Wrapper;
 class MetaObject : public QMetaObject
 {
 public:
-    MetaObject(const QSharedPointer<const Exporter> &exporter);
+    MetaObject(const std::shared_ptr<const Exporter> &exporter);
     ~MetaObject();
 
-    QSharedPointer<const Exporter> exporter() const { return mExporter; }
+    std::shared_ptr<const Exporter> exporter() const { return mExporter; }
     int metaCall(QObject *object, Call call, int index, void **argv) const;
 
 private:
 
-    QSharedPointer<const Exporter> mExporter;
-    QScopedPointer<QMetaObject, QScopedPointerPodDeleter> mPrototype;
+    std::shared_ptr<const Exporter> mExporter;
+    std::shared_ptr<QMetaObject> mPrototype;
 };
 
 } // namespace QmlBind

--- a/qmlbind/src/signalemitter.cpp
+++ b/qmlbind/src/signalemitter.cpp
@@ -11,7 +11,7 @@ SignalEmitter::SignalEmitter()
 
 void SignalEmitter::emitSignal(const QByteArray &name, int argc, const QJSValue *const *argv) const
 {
-    QSharedPointer<const MetaObject> metaObj = mWrapper->qmlbindMetaObject();
+    std::shared_ptr<const MetaObject> metaObj = mWrapper->qmlbindMetaObject();
     int index = metaObj->exporter()->signalIndexMap().value(name, -1);
     if (index == -1) {
         qWarning() << "no such signal found:" << name;
@@ -35,7 +35,7 @@ void SignalEmitter::emitSignal(const QByteArray &name, int argc, const QJSValue 
     argv_with_retvalue[0] = nullptr;
     std::copy(argv, argv + argc, argv_with_retvalue + 1);
 
-    QMetaObject::activate(mWrapper, metaObj.data(), index,
+    QMetaObject::activate(mWrapper, metaObj.get(), index,
                           const_cast<void**>(reinterpret_cast<const void **>(argv_with_retvalue)));
 }
 

--- a/qmlbind/src/typeregisterer.cpp
+++ b/qmlbind/src/typeregisterer.cpp
@@ -13,7 +13,7 @@ namespace QmlBind {
 template <int Index>
 void TypeRegisterer::create(void *memory)
 {
-    QSharedPointer<const MetaObject> metaobj = TypeRegisterer::instance().mMetaObjects[Index];
+    std::shared_ptr<const MetaObject> metaobj = TypeRegisterer::instance().mMetaObjects[Index];
     Backref classRef = metaobj->exporter()->classRef();
     SignalEmitter *emitter = new SignalEmitter();
     Backref ref = classRef.interface()->newObject(classRef, emitter);
@@ -49,7 +49,7 @@ TypeRegisterer::TypeRegisterer() :
     CreationCallbacksSetter<MAX_CALLBACK_COUNT>().set(this);
 }
 
-int TypeRegisterer::registerType(const QSharedPointer<const MetaObject> &metaObject, const char *uri, int versionMajor, int versionMinor, const char *qmlName)
+int TypeRegisterer::registerType(const std::shared_ptr<const MetaObject> &metaObject, const char *uri, int versionMajor, int versionMinor, const char *qmlName)
 {
     int index = mMetaObjects.size();
     if (MAX_CALLBACK_COUNT <= index) {
@@ -65,7 +65,7 @@ int TypeRegisterer::registerType(const QSharedPointer<const MetaObject> &metaObj
     return true;
 }
 
-void TypeRegisterer::registerType(const QSharedPointer<const MetaObject> &metaObject, CreationCallback create, const char *uri, int versionMajor, int versionMinor, const char *qmlName)
+void TypeRegisterer::registerType(const std::shared_ptr<const MetaObject> &metaObject, CreationCallback create, const char *uri, int versionMajor, int versionMinor, const char *qmlName)
 {
     QByteArray className;
     className += metaObject->className();
@@ -83,7 +83,7 @@ void TypeRegisterer::registerType(const QSharedPointer<const MetaObject> &metaOb
         sizeof(Wrapper), create,
         QString(),
 
-        uri, versionMajor, versionMinor, qmlName, metaObject.data(),
+        uri, versionMajor, versionMinor, qmlName, metaObject.get(),
 
         0, 0,
 

--- a/qmlbind/src/typeregisterer.h
+++ b/qmlbind/src/typeregisterer.h
@@ -2,6 +2,7 @@
 
 #include <QVector>
 #include <QSharedPointer>
+#include <memory>
 
 namespace QmlBind {
 

--- a/qmlbind/src/typeregisterer.h
+++ b/qmlbind/src/typeregisterer.h
@@ -11,7 +11,7 @@ class TypeRegisterer
 {
 public:
     static TypeRegisterer &instance();
-    int registerType(const QSharedPointer<const MetaObject> &metaObject, const char *uri, int versionMajor, int versionMinor, const char *qmlName);
+    int registerType(const std::shared_ptr<const MetaObject> &metaObject, const char *uri, int versionMajor, int versionMinor, const char *qmlName);
 
 private:
     typedef void (*CreationCallback)(void *);
@@ -19,9 +19,9 @@ private:
 
     TypeRegisterer();
     template <int Index> static void create(void *memory);
-    void registerType(const QSharedPointer<const MetaObject> &metaObject, CreationCallback create, const char *uri, int versionMajor, int versionMinor, const char *qmlName);
+    void registerType(const std::shared_ptr<const MetaObject> &metaObject, CreationCallback create, const char *uri, int versionMajor, int versionMinor, const char *qmlName);
 
-    QVector<QSharedPointer<const MetaObject> >  mMetaObjects;
+    QVector<std::shared_ptr<const MetaObject> >  mMetaObjects;
     QVector<CreationCallback> mCreationCallbacks;
 };
 

--- a/qmlbind/src/util.h
+++ b/qmlbind/src/util.h
@@ -5,9 +5,9 @@
 namespace QmlBind {
 
 template <typename T>
-QSharedPointer<T> *newSharedPointer(T *ptr)
+std::shared_ptr<T> *newSharedPointer(T *ptr)
 {
-    return new QSharedPointer<T>(ptr);
+    return new std::shared_ptr<T>(ptr);
 }
 
 }

--- a/qmlbind/src/util.h
+++ b/qmlbind/src/util.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QSharedPointer>
+#include <memory>
 
 namespace QmlBind {
 

--- a/qmlbind/src/wrapper.cpp
+++ b/qmlbind/src/wrapper.cpp
@@ -4,7 +4,7 @@
 
 namespace QmlBind {
 
-Wrapper::Wrapper(const QSharedPointer<const MetaObject> &metaObject, const Backref &ref) :
+Wrapper::Wrapper(const std::shared_ptr<const MetaObject> &metaObject, const Backref &ref) :
     mMetaObject(metaObject),
     mRef(ref)
 {
@@ -12,7 +12,7 @@ Wrapper::Wrapper(const QSharedPointer<const MetaObject> &metaObject, const Backr
 
 const QMetaObject *Wrapper::metaObject() const
 {
-    return mMetaObject.data();
+    return mMetaObject.get();
 }
 
 int Wrapper::qt_metacall(QMetaObject::Call call, int index, void **argv)

--- a/qmlbind/src/wrapper.h
+++ b/qmlbind/src/wrapper.h
@@ -12,17 +12,17 @@ class MetaObject;
 class Wrapper : public QObject
 {
 public:
-    Wrapper(const QSharedPointer<const MetaObject> &metaObject, const Backref &ref);
+    Wrapper(const std::shared_ptr<const MetaObject> &metaObject, const Backref &ref);
 
     const QMetaObject *metaObject() const Q_DECL_OVERRIDE;
     int qt_metacall(QMetaObject::Call call, int index, void **argv) Q_DECL_OVERRIDE;
 
     Backref backref() { return mRef; }
-    const QSharedPointer<const MetaObject> qmlbindMetaObject() const { return mMetaObject; }
+    const std::shared_ptr<const MetaObject> qmlbindMetaObject() const { return mMetaObject; }
 
 private:
 
-    QSharedPointer<const MetaObject> mMetaObject;
+    std::shared_ptr<const MetaObject> mMetaObject;
     Backref mRef;
 };
 


### PR DESCRIPTION
Use `std::shared_ptr` instead of `QSharedPointer`.
Required for Qt 5.2 support.