### PR TITLE
Make install prefix configurable

### DIFF
--- a/qmlbind/qmlbind.pro
+++ b/qmlbind/qmlbind.pro
@@ -66,13 +66,17 @@ macx {
 }
 
 unix {
+    isEmpty(INSTALL_PREFIX) {
+        INSTALL_PREFIX=/usr
+    }
+
     for(header, PUBLIC_HEADERS) {
-       path = $${INSTALL_PREFIX}/usr/$${dirname(header)}
+       path = $${INSTALL_PREFIX}/$${dirname(header)}
        eval(headers_$${path}.files += $$header)
        eval(headers_$${path}.path = $$path)
        eval(INSTALLS *= headers_$${path})
     }
 
-    target.path = /usr/lib
+    target.path = $${INSTALL_PREFIX}/lib
     INSTALLS += target
 }


### PR DESCRIPTION
Make install prefix configurable with `INSTALL_PREFIX` qmake variable.

Example:

```
> qmake -r INSTALL_PREFIX=/usr/local
```