### PR TITLE
add support for generating pkg-config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@
 *.dll
 *.dylib
 
+# pkg-config artifacts
+*.pc
+*.prl
+
 # Qt-es
 
 /.qmake.cache

--- a/qmlbind/qmlbind.pro
+++ b/qmlbind/qmlbind.pro
@@ -4,6 +4,12 @@ TARGET = qmlbind
 TEMPLATE = lib
 CONFIG += c++11
 QMAKE_CFLAGS += "-std=c99"
+
+CONFIG += create_pc create_prl no_install_prl
+QMAKE_PKGCONFIG_PREFIX = $$INSTALL_PREFIX
+QMAKE_PKGCONFIG_DESTDIR = "pkgconfig"
+QMAKE_PKGCONFIG_NAME = "libqmlbind"
+QMAKE_PKGCONFIG_DESCRIPTION = "A C library for creating QML bindings for other languages easily through exporting objects to QML"
 VERSION = 0.2.0
 
 DEFINES += QMLBIND_LIBRARY


### PR DESCRIPTION
This lets qmake generate a pkg-config file for libqmlbind and puts it to `$PREFIX/lib/pkgconfig` on `make install`.